### PR TITLE
Elf relocation handler and loader/extension

### DIFF
--- a/src/main/java/ghidra/rl78/elf/RL78Constants.java
+++ b/src/main/java/ghidra/rl78/elf/RL78Constants.java
@@ -1,0 +1,9 @@
+package ghidra.rl78.elf;
+
+public class RL78Constants {
+
+	public static final int MACHINE_TYPE = 197;
+
+	private RL78Constants() {
+	}
+}

--- a/src/main/java/ghidra/rl78/elf/RL78ElfExtension.java
+++ b/src/main/java/ghidra/rl78/elf/RL78ElfExtension.java
@@ -1,0 +1,43 @@
+package ghidra.rl78.elf;
+
+import ghidra.app.util.bin.format.elf.ElfHeader;
+import ghidra.app.util.bin.format.elf.ElfLoadHelper;
+import ghidra.app.util.bin.format.elf.extend.ElfExtension;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.Memory;
+import ghidra.util.classfinder.ExtensionPointProperties;
+import ghidra.util.task.TaskMonitor;
+
+@ExtensionPointProperties(priority = 2)
+public class RL78ElfExtension extends ElfExtension {
+
+	@Override
+	public boolean canHandle(ElfHeader elf) {
+		return elf.e_machine() == RL78Constants.MACHINE_TYPE;
+	}
+
+	@Override
+	public boolean canHandle(ElfLoadHelper elfLoadHelper) {
+		return canHandle(elfLoadHelper.getElfHeader());
+	}
+
+	@Override
+	public String getDataTypeSuffix() {
+		return "rl78";
+	}
+
+	@Override
+	public void processElf(ElfLoadHelper helper, TaskMonitor monitor) {
+		Program program = helper.getProgram();
+		Memory mem = program.getMemory();
+		Address ram = helper.getDefaultAddress(0);
+		Address start = helper.getDefaultAddress(0xF0000);
+		try {
+			mem.createByteMappedBlock("MIRROR", start, ram, 0x10000, false);
+		} catch (Exception e) {
+			helper.getLog().appendException(e);
+		}
+	}
+
+}

--- a/src/main/java/ghidra/rl78/elf/RL78ElfLoader.java
+++ b/src/main/java/ghidra/rl78/elf/RL78ElfLoader.java
@@ -1,0 +1,96 @@
+package ghidra.rl78.elf;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import ghidra.app.util.bin.ByteProvider;
+import ghidra.app.util.bin.format.elf.ElfException;
+import ghidra.app.util.bin.format.elf.ElfHeader;
+import ghidra.app.util.opinion.ElfLoader;
+import ghidra.app.util.opinion.LoadSpec;
+import ghidra.app.util.opinion.LoaderTier;
+import ghidra.app.util.opinion.QueryOpinionService;
+import ghidra.app.util.opinion.QueryResult;
+import ghidra.app.util.Option;
+import ghidra.framework.model.DomainObject;
+import ghidra.program.model.lang.Endian;
+
+import generic.continues.RethrowContinuesFactory;
+
+public class RL78ElfLoader extends ElfLoader {
+
+	@Override
+	public Collection<LoadSpec> findSupportedLoadSpecs(ByteProvider provider) throws IOException {
+		try {
+			ElfHeader elf = ElfHeader.createElfHeader(RethrowContinuesFactory.INSTANCE, provider);
+			if (elf.e_machine() == RL78Constants.MACHINE_TYPE) {
+				return getLoadSpecs(provider);
+			}
+		} catch (ElfException e) {
+			// do nothing
+		}
+		return Collections.emptyList();
+	}
+
+	private Collection<LoadSpec> getLoadSpecs(ByteProvider provider) throws IOException {
+		List<LoadSpec> loadSpecs = new ArrayList<>();
+
+		try {
+			ElfHeader elf = ElfHeader.createElfHeader(RethrowContinuesFactory.INSTANCE, provider);
+			List<QueryResult> results =
+				QueryOpinionService.query(super.getName(), elf.getMachineName(), elf.getFlags());
+			for (QueryResult result : results) {
+				boolean add = true;
+				// Some languages are defined with sizes smaller than 32
+				if (elf.is32Bit() && result.pair.getLanguageDescription().getSize() > 32) {
+					add = false;
+				}
+				if (elf.is64Bit() && result.pair.getLanguageDescription().getSize() <= 32) {
+					add = false;
+				}
+				if (elf.isLittleEndian() &&
+					result.pair.getLanguageDescription().getEndian() != Endian.LITTLE) {
+					add = false;
+				}
+				if (elf.isBigEndian() &&
+					result.pair.getLanguageDescription().getEndian() != Endian.BIG) {
+					add = false;
+				}
+				if (add) {
+					loadSpecs.add(new LoadSpec(this, 0, result));
+				}
+			}
+			if (loadSpecs.isEmpty()) {
+				loadSpecs.add(new LoadSpec(this, 0, true));
+			}
+		}
+		catch (ElfException e) {
+			// not a problem, it's not an elf
+		}
+
+		return loadSpecs;
+	}
+
+	@Override
+	public LoaderTier getTier() {
+		return LoaderTier.SPECIALIZED_TARGET_LOADER;
+	}
+
+	@Override
+	public List<Option> getDefaultOptions(ByteProvider provider, LoadSpec loadSpec,
+			DomainObject domainObject, boolean loadIntoProgram) {
+		List<Option> options =
+			super.getDefaultOptions(provider, loadSpec, domainObject, loadIntoProgram);
+		options.removeIf(o -> o.getName().equals("Image Base"));
+		return options;
+	}
+
+	@Override
+	public String getName() {
+		return "RL78 " + super.getName();
+	}
+
+}

--- a/src/main/java/ghidra/rl78/elf/relocation/RL78ElfRelocationHandler.java
+++ b/src/main/java/ghidra/rl78/elf/relocation/RL78ElfRelocationHandler.java
@@ -1,0 +1,196 @@
+package ghidra.rl78.elf.relocation;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.MemoryByteProvider;
+import ghidra.app.util.bin.format.elf.ElfHeader;
+import ghidra.app.util.bin.format.elf.ElfRelocation;
+import ghidra.app.util.bin.format.elf.ElfSymbol;
+import ghidra.app.util.bin.format.elf.relocation.ElfRelocationContext;
+import ghidra.app.util.bin.format.elf.relocation.ElfRelocationHandler;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.listing.BookmarkManager;
+import ghidra.program.model.listing.BookmarkType;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.Memory;
+import ghidra.program.model.mem.MemoryAccessException;
+import ghidra.rl78.elf.RL78Constants;
+import ghidra.util.exception.AssertException;
+import ghidra.util.exception.NotFoundException;
+
+import static ghidra.rl78.elf.relocation.RL78RelocationConstants.*;
+
+public class RL78ElfRelocationHandler extends ElfRelocationHandler {
+
+	@Override
+	public boolean canRelocate(ElfHeader elf) {
+		return elf.e_machine() == RL78Constants.MACHINE_TYPE;
+	}
+
+	@Override
+	public void relocate(ElfRelocationContext context, ElfRelocation reloc, Address addr)
+			throws MemoryAccessException, NotFoundException {
+
+		HowTo howTo = new HowTo(context, reloc, addr);
+
+		Program program = context.getProgram();
+		BookmarkManager bMan = program.getBookmarkManager();
+		int offset = (int) addr.getOffset();
+
+		switch (reloc.getType()) {
+			case R_RL78_NONE:
+				return;
+			case R_RL78_DIR32:
+				howTo.relocate(2, 32, 0);
+				break;
+			case R_RL78_DIR24S:
+				howTo.relocate(2, 24, 0);
+				break;
+			case R_RL78_DIR16:
+			case R_RL78_DIR16U:
+			case R_RL78_DIR16S:
+				howTo.relocate(1, 16, 0);
+				break;
+			case R_RL78_DIR8:
+			case R_RL78_DIR8U:
+			case R_RL78_DIR8S:
+				howTo.relocate(0, 8, 0);
+				break;
+			case R_RL78_DIR24S_PCREL:
+				howTo.relocate(2, 24, 0, offset);
+				break;
+			case R_RL78_DIR16S_PCREL:
+				howTo.relocate(1, 16, 0, offset);
+				break;
+			case R_RL78_DIR8S_PCREL:
+				howTo.relocate(0, 8, 0, offset);
+				break;
+			case R_RL78_DIR16UL:
+				howTo.relocate(1, 16, 2);
+				break;
+			case R_RL78_DIR16UW:
+				howTo.relocate(1, 16, 1);
+				break;
+			case R_RL78_DIR8UL:
+				howTo.relocate(0, 8, 2);
+				break;
+			case R_RL78_DIR8UW:
+				howTo.relocate(0, 8, 1);
+				break;
+			case R_RL78_DIR32_REV:
+			case R_RL78_DIR16_REV:
+				howTo.relocate(1, 16, 0);
+				break;
+			case R_RL78_DIR3U_PCREL:
+				howTo.relocate(0, 3, 0, offset);
+				break;
+			case R_RL78_RH_RELAX:
+			case R_RL78_RH_SFR:
+			case R_RL78_RH_SADDR:
+			case R_RL78_ABS32:
+			case R_RL78_ABS24S:
+			case R_RL78_ABS16:
+			case R_RL78_ABS16U:
+			case R_RL78_ABS16S:
+			case R_RL78_ABS8:
+			case R_RL78_ABS8U:
+			case R_RL78_ABS8S:
+			case R_RL78_ABS24S_PCREL:
+			case R_RL78_ABS16S_PCREL:
+			case R_RL78_ABS8S_PCREL:
+			case R_RL78_ABS16UL:
+			case R_RL78_ABS16UW:
+			case R_RL78_ABS8UL:
+			case R_RL78_ABS8UW:
+			case R_RL78_ABS32_REV:
+			case R_RL78_ABS16_REV:
+			case R_RL78_SYM:
+			case R_RL78_OPneg:
+			case R_RL78_OPadd:
+			case R_RL78_OPsub:
+			case R_RL78_OPmul:
+			case R_RL78_OPdiv:
+			case R_RL78_OPshla:
+			case R_RL78_OPshra:
+			case R_RL78_OPsctsize:
+			case R_RL78_OPscttop:
+			case R_RL78_OPand:
+			case R_RL78_OPor:
+			case R_RL78_OPxor:
+			case R_RL78_OPnot:
+			case R_RL78_OPmod:
+			case R_RL78_OPromtop:
+			case R_RL78_OPramtop:
+			default:
+				String msg = String.format("Unsupported relocation type %d", reloc.getType());
+				bMan.setBookmark(addr, BookmarkType.ERROR, BookmarkType.ERROR, msg);
+				break;
+		}
+	}
+
+	private static class HowTo {
+
+		private final ElfRelocationContext context;
+		private final Address addr;
+		private final int symbolValue;
+
+		HowTo(ElfRelocationContext context, ElfRelocation reloc, Address addr) {
+			this.context = context;
+			this.addr = addr;
+
+			ElfSymbol sym = null;
+			int symbolIndex = reloc.getSymbolIndex();
+			if (symbolIndex != 0) {
+				sym = context.getSymbol(symbolIndex);
+			}
+
+			this.symbolValue = sym != null ? (int) context.getSymbolValue(sym) : 0;
+		}
+
+		Memory getMemory() {
+			return context.getProgram().getMemory();
+		}
+
+		boolean isLittleEndian() {
+			return !getMemory().isBigEndian();
+		}
+
+		void relocate(int size, int bit, int shift) {
+			relocate(size, bit, shift, 0);
+		}
+
+		void relocate(int size, int bit, int shift, int offset) {
+			if (symbolValue == 0) {
+				return;
+			}
+			try {
+				size++;
+				int oldValue = readInt(size);
+				int newValue = ((oldValue << bit) >> shift) - offset;
+				setInt(newValue | symbolValue, size);
+			} catch (MemoryAccessException e) {
+				// do nothing
+			}
+		}
+
+		int readInt(int len) {
+			MemoryByteProvider provider = new MemoryByteProvider(getMemory(), addr);
+			BinaryReader reader = new BinaryReader(provider, isLittleEndian());
+			try {
+				return (int) reader.readValue(0, len);
+			} catch (IOException e) {
+				throw new AssertException(e);
+			}
+		}
+
+		void setInt(int v, int len) throws MemoryAccessException {
+			ByteBuffer buf = ByteBuffer.allocate(Integer.BYTES);
+			buf.order(isLittleEndian() ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN).putInt(v);
+			getMemory().setBytes(addr, buf.array(), 0, len);
+		}
+	}
+
+}

--- a/src/main/java/ghidra/rl78/elf/relocation/RL78RelocationConstants.java
+++ b/src/main/java/ghidra/rl78/elf/relocation/RL78RelocationConstants.java
@@ -1,0 +1,70 @@
+package ghidra.rl78.elf.relocation;
+
+public class RL78RelocationConstants {
+
+	public static final int R_RL78_NONE = 0x00;
+
+	public static final int R_RL78_DIR32 = 0x01;
+	public static final int R_RL78_DIR24S = 0x02;
+	public static final int R_RL78_DIR16 = 0x03;
+	public static final int R_RL78_DIR16U = 0x04;
+	public static final int R_RL78_DIR16S = 0x05;
+	public static final int R_RL78_DIR8 = 0x06;
+	public static final int R_RL78_DIR8U = 0x07;
+	public static final int R_RL78_DIR8S = 0x08;
+
+	public static final int R_RL78_DIR24S_PCREL = 0x09;
+	public static final int R_RL78_DIR16S_PCREL = 0x0a;
+	public static final int R_RL78_DIR8S_PCREL = 0x0b;
+
+	public static final int R_RL78_DIR16UL = 0x0c;
+	public static final int R_RL78_DIR16UW = 0x0d;
+	public static final int R_RL78_DIR8UL = 0x0e;
+	public static final int R_RL78_DIR8UW = 0x0f;
+	public static final int R_RL78_DIR32_REV = 0x10;
+	public static final int R_RL78_DIR16_REV = 0x11;
+	public static final int R_RL78_DIR3U_PCREL = 0x12;
+
+	public static final int R_RL78_RH_RELAX = 0x2d;
+	public static final int R_RL78_RH_SFR = 0x2e;
+	public static final int R_RL78_RH_SADDR = 0x2f;
+
+	public static final int R_RL78_ABS32 = 0x41;
+	public static final int R_RL78_ABS24S = 0x42;
+	public static final int R_RL78_ABS16 = 0x43;
+	public static final int R_RL78_ABS16U = 0x44;
+	public static final int R_RL78_ABS16S = 0x45;
+	public static final int R_RL78_ABS8 = 0x46;
+	public static final int R_RL78_ABS8U = 0x47;
+	public static final int R_RL78_ABS8S = 0x48;
+	public static final int R_RL78_ABS24S_PCREL = 0x49;
+	public static final int R_RL78_ABS16S_PCREL = 0x4a;
+	public static final int R_RL78_ABS8S_PCREL = 0x4b;
+	public static final int R_RL78_ABS16UL = 0x4c;
+	public static final int R_RL78_ABS16UW = 0x4d;
+	public static final int R_RL78_ABS8UL = 0x4e;
+	public static final int R_RL78_ABS8UW = 0x4f;
+	public static final int R_RL78_ABS32_REV = 0x50;
+	public static final int R_RL78_ABS16_REV = 0x51;
+
+	public static final int R_RL78_SYM = 0x80;
+	public static final int R_RL78_OPneg = 0x81;
+	public static final int R_RL78_OPadd = 0x82;
+	public static final int R_RL78_OPsub = 0x83;
+	public static final int R_RL78_OPmul = 0x84;
+	public static final int R_RL78_OPdiv = 0x85;
+	public static final int R_RL78_OPshla = 0x86;
+	public static final int R_RL78_OPshra = 0x87;
+	public static final int R_RL78_OPsctsize = 0x88;
+	public static final int R_RL78_OPscttop = 0x8d;
+	public static final int R_RL78_OPand = 0x90;
+	public static final int R_RL78_OPor = 0x91;
+	public static final int R_RL78_OPxor = 0x92;
+	public static final int R_RL78_OPnot = 0x93;
+	public static final int R_RL78_OPmod = 0x94;
+	public static final int R_RL78_OPromtop = 0x95;
+	public static final int R_RL78_OPramtop = 0x96;
+
+	private RL78RelocationConstants() {
+	}
+}


### PR DESCRIPTION
The `RL78ElfExtension`'s is just to add in the byte mapped mirror area as it cannot be done in the `pspec`. The `RL78ElfLoader` loader was added because the default image base is placed in the mirror area which causes problems. The relocation handler isn't complete and is not yet compensating for the addend.

Regarding the below code. I cannot seem to find anything to explain why `HL` is being read from the mirror area instead of directly from the address.
https://github.com/MikeM64/RL78_sleigh/blob/467c5ddf9ae221dca3ae992fbbab3226c4292053/data/languages/rl78.slaspec#L678-L681